### PR TITLE
 Improve `ExponentialBackoff` handling

### DIFF
--- a/src/redis.rs
+++ b/src/redis.rs
@@ -77,8 +77,6 @@ impl Actor for RedisActor {
                     // we stop current context, supervisor will restart it.
                     if let Some(timeout) = act.backoff.next_backoff() {
                         ctx.run_later(timeout, |_, ctx| ctx.stop());
-                    } else {
-                        ctx.stop();
                     }
                 }
             })
@@ -88,8 +86,6 @@ impl Actor for RedisActor {
                 // we stop current context, supervisor will restart it.
                 if let Some(timeout) = act.backoff.next_backoff() {
                     ctx.run_later(timeout, |_, ctx| ctx.stop());
-                } else {
-                    ctx.stop();
                 }
             })
             .wait(ctx);

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -37,10 +37,13 @@ impl RedisActor {
     pub fn start<S: Into<String>>(addr: S) -> Addr<Unsync, RedisActor> {
         let addr = addr.into();
 
+        let mut backoff = ExponentialBackoff::default();
+        backoff.max_elapsed_time = None;
+
         Supervisor::start(|_| RedisActor {
             addr: addr,
             cell: None,
-            backoff: ExponentialBackoff::default(),
+            backoff: backoff,
             queue: VecDeque::new(),
         })
     }


### PR DESCRIPTION
The current `ExponentialBackoff` code has two problems:

- When the `max_elapsed_time` is reached the actor will go from being restarted every X sec. to being restarted directly all the time, due to the "`None` means `ctx.stop()`" implementation

- The default `ExponentialBackoff` implementation sets `max_elapsed_time` to 15 min.

This PR changes the code to:

- If `ExponentialBackoff` explicitly returns a `None` timeout we should comply and not restart the actor anymore. This should be accomplished by **not** calling `ctx.stop()` when `None` is returned.

- Use the default `ExponentialBackoff` implementation but explicitly set `max_elapsed_time` to `None` so that it will never stop the actor by default.