### PR TITLE
Update to redis-async 0.3 and release actix-redis 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-redis"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Redis integration for actix framework"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,13 @@ failure = "^0.1.1"
 futures = "0.1"
 tokio-io = "0.1"
 tokio-core = "0.1"
-redis-async = "0.0"
+redis-async = ">= 0.0.6,  < 0.4"
 
 # actix web session
 actix-web = { version="0.6", optional=true }
 cookie = { version="0.10", features=["percent-encode", "secure"], optional=true }
 http = { version="0.1", optional=true }
-rand = { version="0.3", optional=true }
+rand = { version="0.5", optional=true }
 serde = { version="1.0", optional=true }
 serde_json = { version="1.0", optional=true }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -11,6 +11,7 @@ use futures::future::{err as FutErr, ok as FutOk, Either};
 use futures::Future;
 use http::header::{self, HeaderValue};
 use rand::{self, Rng};
+use rand::distributions::Alphanumeric;
 use redis_async::resp::RespValue;
 use serde_json;
 
@@ -194,7 +195,7 @@ impl Inner {
             (value.clone(), None)
         } else {
             let mut rng = rand::OsRng::new().unwrap();
-            let value = String::from_iter(rng.gen_ascii_chars().take(32));
+            let value = String::from_iter(rng.sample_iter(&Alphanumeric).take(32));
 
             let mut cookie = Cookie::new(self.name.clone(), value.clone());
             cookie.set_path("/");


### PR DESCRIPTION
Hope this is alright!

Changes to redis-async 0.7-0.3.2: https://github.com/benashford/redis-async-rs/compare/bfe0a7162825495f1833baf03ee1edcf816e5c1c...a83ddfe2aad4ba2f8655a1c00a86ad4b837e596d

I'm not an expert on the actix ecosystem yet, but this seems to be a sane update. I've run the tests and examples, and they are all fully functional. It seems all of redis-async's breaking changes were to interfaces actix-redis doesn't directly use?

This includes a commit to update the project version to 0.5.0.