### PR TITLE
Re-export SameSite so it's immediately usable from this package...

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ extern crate serde_json;
 mod session;
 #[cfg(feature = "web")]
 pub use session::RedisSessionBackend;
+#[cfg(feature = "web")]
+pub use cookie::{SameSite};
 
 /// General purpose actix redis error
 #[derive(Fail, Debug)]


### PR DESCRIPTION
Was using this in something and went to deal with `SameSite` cookie stuff, and... well, it's a pain in the ass when I have to hunt for this kind of stuff. Any argument for this package not hoisting the import so it's usable without also needing to add `cookie` to `Cargo.toml`?