### PR TITLE
change session ttl type u16 to i32

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -87,7 +87,7 @@ impl RedisSessionBackend {
     }
 
     /// Set time to live in seconds for session value
-    pub fn ttl(mut self, ttl: u16) -> Self {
+    pub fn ttl(mut self, ttl: i32) -> Self {
         Rc::get_mut(&mut self.0).unwrap().ttl = format!("{}", ttl);
         self
     }


### PR DESCRIPTION
std::u16::MAX is 65535 secs (18.2 hours). it is too short.
redis EXPIRE command can accept std::i32::MAX 2147483647 secs (68 years). 

https://stackoverflow.com/questions/28085785/set-cache-redis-expiration-to-1-year/28087290#28087290