### PR TITLE
Allow redis to be started on a specific database instead of default of 0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-redis"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Redis integration for actix framework"
 license = "MIT/Apache-2.0"

--- a/src/session.rs
+++ b/src/session.rs
@@ -86,6 +86,20 @@ impl RedisSessionBackend {
         }))
     }
 
+    pub fn new_db<S: Into<String>>(addr: S, db: u8, key: &[u8]) -> RedisSessionBackend {
+        RedisSessionBackend(Rc::new(Inner {
+            key: Key::from_master(key),
+            ttl: "7200".to_owned(),
+            addr: RedisActor::start_db(addr, db),
+            name: "actix-session".to_owned(),
+            path: "/".to_owned(),
+            domain: None,
+            secure: false,
+            max_age: Some(Duration::days(7)),
+            same_site: None,
+        }))
+    }
+
     /// Set time to live in seconds for session value
     pub fn ttl(mut self, ttl: u16) -> Self {
         Rc::get_mut(&mut self.0).unwrap().ttl = format!("{}", ttl);


### PR DESCRIPTION
I use the same redis instance for multiple services so i like to be able to select the database, though i learned today that it doesn't working when redis is in clustered mode. (https://redis.io/commands/select) Just thought it would be nice to have for those of us not using clustered mode.