### PR TITLE
updated session logic to support login and logout functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ Cargo.lock
 target/
 guide/build/
 /gh-pages
+/.history
 
 *.so
 *.out

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changes
 
+
+## 0.7.0 (2019-xx-xx)
+
+* Upgraded logic that evaluates session state, including new SessionStatus field,
+  and introduced ``session.renew()`` and ``session.purge()`` functionality.
+  Use ``renew()`` to cycle the session key at successful login.  ``renew()`` keeps a
+  session's state while replacing the old cookie and session key with new ones.
+  Use ``purge()`` at logout to invalidate the session cookie and remove the
+  session's redis cache entry.
+
+
 ## 0.6.0 (2019-05-18)
 
 * actix-web 1.0.0 compatibility

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 
-## 0.7.0 (2019-xx-xx)
+## 0.6.0 (2019-07-08)
+
+* actix-web 1.0.0 compatibility
 
 * Upgraded logic that evaluates session state, including new SessionStatus field,
   and introduced ``session.renew()`` and ``session.purge()`` functionality.
@@ -10,10 +12,6 @@
   Use ``purge()`` at logout to invalidate the session cookie and remove the
   session's redis cache entry.
 
-
-## 0.6.0 (2019-05-18)
-
-* actix-web 1.0.0 compatibility
 
 
 ## 0.5.1 (2018-08-02)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-redis"
-version = "0.7.0"
+version = "0.6.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Redis integration for actix framework"
 license = "MIT/Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-redis"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Redis integration for actix framework"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
This PR features logic used to support login and logout functionality facilitated by key renewal and purging of cache + cookie.

To see the impact of these changes, see [main.rs in this repo](https://github.com/Dowwie/actix_session_test/blob/master/src/main.rs).

Use actix-web on master branch until 1.0.4 to access new actix-session functionality.