### PR TITLE
replace `redis-async` with `redis` crate

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,28 @@
 # Changes
 
+## 0.7.0 (2019-08-24)
+
+* Replace ``redis-async`` with ``redis`` crate.
+
+* Add redis authentication support.
+
+* Add redis Unix socket support.
+
+* Add redis db selection.
+
+### Breaking changes
+
+* Change type of an argument of a ``RedisSession::ttl()`` method to ``i64``.
+
+* Change redis address format to:
+  ``redis://[:<passwd>@]<hostname>[:port][/<db>]`` for TCP connection
+  or ``redis+unix://[:<passwd>@]localhost<path>[?db=<db>]`` for Unix socket.
+
 ## 0.6.1 (2019-07-19)
 
 * remove ClonableService usage
 
 * added comprehensive tests for session workflow
-
 
 ## 0.6.0 (2019-07-08)
 
@@ -18,19 +35,15 @@
   Use ``purge()`` at logout to invalidate the session cookie and remove the
   session's redis cache entry.
 
-
-
 ## 0.5.1 (2018-08-02)
 
 * Use cookie 0.11
-
 
 ## 0.5.0 (2018-07-21)
 
 * Session cookie configuration
 
 * Actix/Actix-web 0.7 compatibility
-
 
 ## 0.4.0 (2018-05-08)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix-redis"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Redis integration for actix framework"
 license = "MIT/Apache-2.0"
@@ -34,10 +34,7 @@ log = "0.4.6"
 backoff = "0.1.5"
 derive_more = "0.15.0"
 futures = "0.1.28"
-tokio-io = "0.1.12"
-tokio-codec = "0.1.1"
-tokio-tcp = "0.1.3"
-redis-async = "0.4.5"
+redis = "0.11.0"
 time = "0.1.42"
 
 # actix web session

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Actix redis [![Build Status](https://travis-ci.org/actix/actix-redis.svg?branch=master)](https://travis-ci.org/actix/actix-redis) [![codecov](https://codecov.io/gh/actix/actix-redis/branch/master/graph/badge.svg)](https://codecov.io/gh/actix/actix-redis) [![crates.io](http://meritbadge.herokuapp.com/actix-redis)](https://crates.io/crates/actix-redis) 
+# Actix redis [![Build Status](https://travis-ci.org/actix/actix-redis.svg?branch=master)](https://travis-ci.org/actix/actix-redis) [![codecov](https://codecov.io/gh/actix/actix-redis/branch/master/graph/badge.svg)](https://codecov.io/gh/actix/actix-redis) [![crates.io](http://meritbadge.herokuapp.com/actix-redis)](https://crates.io/crates/actix-redis)
 
 Redis integration for actix framework.
 
@@ -8,7 +8,7 @@ Redis integration for actix framework.
 * [API Documentation (Releases)](https://docs.rs/actix-redis/)
 * [Chat on gitter](https://gitter.im/actix/actix)
 * Cargo package: [actix-redis](https://crates.io/crates/actix-redis)
-* Minimum supported Rust version: 1.26 or later
+* Minimum supported Rust version: 1.27 or later
 
 
 ## Redis session backend
@@ -42,7 +42,7 @@ fn main() {
             .middleware(middleware::Logger::default())
             // cookie session middleware
             .middleware(SessionStorage::new(
-                RedisSessionBackend::new("127.0.0.1:6379", &[0; 32])
+                RedisSessionBackend::new("redis://127.0.0.1:6379", &[0; 32])
             ))
             // register simple route, handle all methods
             .resource("/", |r| r.f(index)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,13 +9,13 @@
 //!
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate redis_async;
+
 #[macro_use]
 extern crate derive_more;
 
+extern crate redis as redisrs;
+
 mod redis;
-pub use redis::{Command, RedisActor};
 
 #[cfg(feature = "web")]
 mod session;
@@ -28,15 +28,11 @@ pub use session::RedisSession;
 #[derive(Debug, Display, From)]
 pub enum Error {
     #[display(fmt = "Redis error {}", _0)]
-    Redis(redis_async::error::Error),
+    Redis(redisrs::RedisError),
     /// Receiving message during reconnecting
     #[display(fmt = "Redis: Not connected")]
     NotConnected,
-    /// Cancel all waters when connection get dropped
-    #[display(fmt = "Redis: Disconnected")]
-    Disconnected,
 }
 
 // re-export
-pub use redis_async::error::Error as RespError;
-pub use redis_async::resp::RespValue;
+pub use crate::redis::{RedisCmd, RedisActor, RedisValue};

--- a/src/redis.rs
+++ b/src/redis.rs
@@ -1,39 +1,31 @@
-use std::collections::VecDeque;
-use std::io;
-
-use actix::actors::resolver::{Connect, Resolver};
+use actix::fut::{err, ok};
 use actix::prelude::*;
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
-use futures::unsync::oneshot;
-use futures::Future;
-use redis_async::error::Error as RespError;
-use redis_async::resp::{RespCodec, RespValue};
-use tokio_codec::FramedRead;
-use tokio_io::io::WriteHalf;
-use tokio_io::AsyncRead;
-use tokio_tcp::TcpStream;
+use redis;
+
+pub use redis::Value as RedisValue;
 
 use crate::Error;
 
-/// Command for send data to Redis
-#[derive(Debug)]
-pub struct Command(pub RespValue);
-
-impl Message for Command {
-    type Result = Result<RespValue, Error>;
+pub enum RedisCmd {
+    Set(String, String),
+    SetWithEx(String, String, i64),
+    Get(String),
+    Del(String),
 }
 
-/// Redis comminucation actor
+impl Message for RedisCmd {
+    type Result = Result<redis::Value, Error>;
+}
+
 pub struct RedisActor {
     addr: String,
     backoff: ExponentialBackoff,
-    cell: Option<actix::io::FramedWrite<WriteHalf<TcpStream>, RespCodec>>,
-    queue: VecDeque<oneshot::Sender<Result<RespValue, Error>>>,
+    client: Option<redis::aio::SharedConnection>,
 }
 
 impl RedisActor {
-    /// Start new `Supervisor` with `RedisActor`.
     pub fn start<S: Into<String>>(addr: S) -> Addr<RedisActor> {
         let addr = addr.into();
 
@@ -42,9 +34,8 @@ impl RedisActor {
 
         Supervisor::start(|_| RedisActor {
             addr,
-            cell: None,
-            backoff: backoff,
-            queue: VecDeque::new(),
+            backoff,
+            client: None,
         })
     }
 }
@@ -53,37 +44,17 @@ impl Actor for RedisActor {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Context<Self>) {
-        Resolver::from_registry()
-            .send(Connect::host(self.addr.as_str()))
+        let client = redis::Client::open(self.addr.as_ref()).unwrap();
+        client
+            .get_shared_async_connection()
             .into_actor(self)
-            .map(|res, act, ctx| match res {
-                Ok(stream) => {
-                    info!("Connected to redis server: {}", act.addr);
-
-                    let (r, w) = stream.split();
-
-                    // configure write side of the connection
-                    let framed = actix::io::FramedWrite::new(w, RespCodec, ctx);
-                    act.cell = Some(framed);
-
-                    // read side of the connection
-                    ctx.add_stream(FramedRead::new(r, RespCodec));
-
-                    act.backoff.reset();
-                }
-                Err(err) => {
-                    error!("Can not connect to redis server: {}", err);
-                    // re-connect with backoff time.
-                    // we stop current context, supervisor will restart it.
-                    if let Some(timeout) = act.backoff.next_backoff() {
-                        ctx.run_later(timeout, |_, ctx| ctx.stop());
-                    }
-                }
+            .map(|con, act, _| {
+                info!("Connected to redis server: {}", act.addr);
+                act.client = Some(con);
+                act.backoff.reset();
             })
             .map_err(|err, act, ctx| {
                 error!("Can not connect to redis server: {}", err);
-                // re-connect with backoff time.
-                // we stop current context, supervisor will restart it.
                 if let Some(timeout) = act.backoff.next_backoff() {
                     ctx.run_later(timeout, |_, ctx| ctx.stop());
                 }
@@ -94,47 +65,43 @@ impl Actor for RedisActor {
 
 impl Supervised for RedisActor {
     fn restarting(&mut self, _: &mut Self::Context) {
-        self.cell.take();
-        for tx in self.queue.drain(..) {
-            let _ = tx.send(Err(Error::Disconnected));
-        }
+        self.client.take();
     }
 }
 
-impl actix::io::WriteHandler<io::Error> for RedisActor {
-    fn error(&mut self, err: io::Error, _: &mut Self::Context) -> Running {
-        warn!("Redis connection dropped: {} error: {}", self.addr, err);
-        Running::Stop
-    }
-}
+impl Handler<RedisCmd> for RedisActor {
+    type Result = ResponseActFuture<Self, redis::Value, Error>;
 
-impl StreamHandler<RespValue, RespError> for RedisActor {
-    fn error(&mut self, err: RespError, _: &mut Self::Context) -> Running {
-        if let Some(tx) = self.queue.pop_front() {
-            let _ = tx.send(Err(err.into()));
-        }
-        Running::Stop
-    }
-
-    fn handle(&mut self, msg: RespValue, _: &mut Self::Context) {
-        if let Some(tx) = self.queue.pop_front() {
-            let _ = tx.send(Ok(msg));
-        }
-    }
-}
-
-impl Handler<Command> for RedisActor {
-    type Result = ResponseFuture<RespValue, Error>;
-
-    fn handle(&mut self, msg: Command, _: &mut Self::Context) -> Self::Result {
-        let (tx, rx) = oneshot::channel();
-        if let Some(ref mut cell) = self.cell {
-            self.queue.push_back(tx);
-            cell.write(msg.0);
+    fn handle(&mut self, msg: RedisCmd, _: &mut Self::Context) -> Self::Result {
+        if let Some(con) = self.client.clone() {
+            let res = match msg {
+                RedisCmd::Get(key) => redis::cmd("GET").arg(key).query_async(con),
+                RedisCmd::Del(key) => redis::cmd("DEL").arg(key).query_async(con),
+                RedisCmd::Set(key, val) => {
+                    redis::cmd("SET").arg(key).arg(val).query_async(con)
+                }
+                RedisCmd::SetWithEx(key, val, ttl) => redis::cmd("SET")
+                    .arg(key)
+                    .arg(val)
+                    .arg("EX")
+                    .arg(ttl)
+                    .query_async(con),
+            }
+            .map(|t| t.1)
+            .into_actor(self)
+            .then(|res, act, ctx| match res {
+                Ok(res_ok) => ok(res_ok),
+                Err(res_err) => {
+                    if res_err.is_io_error() {
+                        warn!("Redis connection error: {} error: {}", act.addr, res_err);
+                        ctx.stop();
+                    }
+                    err(Error::Redis(res_err))
+                }
+            });
+            Box::new(res)
         } else {
-            let _ = tx.send(Err(Error::NotConnected));
+            Box::new(err(Error::NotConnected))
         }
-
-        Box::new(rx.map_err(|_| Error::Disconnected).and_then(|res| res))
     }
 }

--- a/tests/test_redis.rs
+++ b/tests/test_redis.rs
@@ -1,19 +1,16 @@
-#[macro_use]
-extern crate redis_async;
-
 use actix::prelude::*;
-use actix_redis::{Command, Error, RedisActor, RespValue};
+use actix_redis::{Error, RedisActor, RedisCmd, RedisValue};
 use futures::Future;
 
 #[test]
 fn test_error_connect() -> std::io::Result<()> {
     let sys = System::new("test");
 
-    let addr = RedisActor::start("localhost:54000");
+    let addr = RedisActor::start("redis://localhost:54000");
     let _addr2 = addr.clone();
 
     Arbiter::spawn_fn(move || {
-        addr.send(Command(resp_array!["GET", "test"])).then(|res| {
+        addr.send(RedisCmd::Get("test".to_string())).then(|res| {
             match res {
                 Ok(Err(Error::NotConnected)) => (),
                 _ => panic!("Should not happen {:?}", res),
@@ -28,25 +25,61 @@ fn test_error_connect() -> std::io::Result<()> {
 
 #[test]
 fn test_redis() -> std::io::Result<()> {
-    env_logger::init();
+    let _ = env_logger::builder().is_test(true).try_init();
     let sys = System::new("test");
 
-    let addr = RedisActor::start("127.0.0.1:6379");
+    let addr = RedisActor::start("redis://127.0.0.1:6379");
     let _addr2 = addr.clone();
 
     Arbiter::spawn_fn(move || {
         let addr2 = addr.clone();
-        addr.send(Command(resp_array!["SET", "test", "value"]))
+        addr.send(RedisCmd::Set("test".to_string(), "value".to_string()))
             .then(move |res| match res {
                 Ok(Ok(resp)) => {
-                    assert_eq!(resp, RespValue::SimpleString("OK".to_owned()));
-                    addr2.send(Command(resp_array!["GET", "test"])).then(|res| {
+                    assert_eq!(resp, RedisValue::Okay);
+                    addr2.send(RedisCmd::Get("test".to_string())).then(|res| {
                         match res {
                             Ok(Ok(resp)) => {
                                 println!("RESP: {:?}", resp);
                                 assert_eq!(
                                     resp,
-                                    RespValue::BulkString((&b"value"[..]).into())
+                                    RedisValue::Data((&b"value"[..]).into())
+                                );
+                            }
+                            _ => panic!("Should not happen {:?}", res),
+                        }
+                        System::current().stop();
+                        Ok(())
+                    })
+                }
+                _ => panic!("Should not happen {:?}", res),
+            })
+    });
+
+    sys.run()
+}
+
+#[test]
+fn test_redis_with_expire() -> std::io::Result<()> {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let sys = System::new("test");
+
+    let addr = RedisActor::start("redis://127.0.0.1:6379");
+    let _addr2 = addr.clone();
+
+    Arbiter::spawn_fn(move || {
+        let addr2 = addr.clone();
+        addr.send(RedisCmd::SetWithEx("test".to_string(), "value".to_string(), 60))
+            .then(move |res| match res {
+                Ok(Ok(resp)) => {
+                    assert_eq!(resp, RedisValue::Okay);
+                    addr2.send(RedisCmd::Get("test".to_string())).then(|res| {
+                        match res {
+                            Ok(Ok(resp)) => {
+                                println!("RESP: {:?}", resp);
+                                assert_eq!(
+                                    resp,
+                                    RedisValue::Data((&b"value"[..]).into())
                                 );
                             }
                             _ => panic!("Should not happen {:?}", res),


### PR DESCRIPTION
Hi, I've replaced `redis-async` with `redis` crate what simplifies some parts of the code and gives new features like Unix socket connection, redis authentication and db selection.

Regards :)

Resolves issues #29, #15 and prs #19, #17.