### PR TITLE
Bump actix-http to 0.2.11.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.40", optional = true }
 env_logger = "0.6.2"
 actix-http-test = "0.2.5"
-actix-http = "0.2.11"
+actix-http = "0.3.0-alpha.2"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.40", optional = true }
 env_logger = "0.6.2"
 actix-http-test = "0.2.5"
-actix-http = "0.2.10"
+actix-http = "0.2.11"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rand = { version = "0.7.0", optional = true }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.40", optional = true }
 env_logger = "0.6.2"
-actix-http-test = "0.2.5"
+actix-http-test = "0.3.0-alpha.2"
 actix-http = "0.3.0-alpha.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Just bumping a dependency. I've been trying to integrate actix-redis into my webapp, but ran into a few dependency versioning errors (`failed to select a version for ring`). Jumping to 0.2.11 for actix-http seemed to fix the discrepancy.