### PR TITLE
bump actix-web version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ tokio = "0.2.6"
 tokio-util = "0.2.0"
 
 # actix web session
-actix-web = { version = "2.0.0-rc", optional = true }
+actix-web = { version = "2.0.0", optional = true }
 actix-service = { version = "1.0.0", optional = true }
 actix-session = { version = "0.3.0", optional = true }
 rand = { version = "0.7.0", optional = true }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -32,6 +32,6 @@ async fn main() -> std::io::Result<()> {
             .service(web::resource("/").to(index))
     })
     .bind("0.0.0.0:8080")?
-    .start()
+    .run()
     .await
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -10,7 +10,7 @@ use actix_web::cookie::{Cookie, CookieJar, Key, SameSite};
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::http::header::{self, HeaderValue};
 use actix_web::{error, Error, HttpMessage};
-use futures::future::{err, ok, Future, Ready};
+use futures::future::{ok, Future, Ready};
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use redis_async::resp::RespValue;
 use time::{self, Duration};


### PR DESCRIPTION
`HttpServer::start` is renamed to `HttpServer::run`.
https://github.com/actix/actix-web/blob/master/CHANGES.md#200---2019-12-25

Also removed `futures::future::err` as it's not used.