### PR TITLE
Upgrade `time` to 0.2.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changes
 
+## [Unreleased] 2019-xx-xx
+
+* Update the `time` dependency to 0.2.5
+
 ## [0.8.0] 2019-12-20
 
 * Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 redis-async = "0.6.1"
 actix-rt = "1.0.0"
-time = "0.1.42"
+time = "0.2.1"
 tokio = "0.2.6"
 tokio-util = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 redis-async = "0.6.1"
 actix-rt = "1.0.0"
-time = "0.2.1"
+time = { version = "0.2.2", default-features = false, features = ["std"] }
 tokio = "0.2.6"
 tokio-util = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ derive_more = "0.99.2"
 futures = "0.3.1"
 redis-async = "0.6.1"
 actix-rt = "1.0.0"
-time = { version = "0.2.2", default-features = false, features = ["std"] }
+time = { version = "0.2.5", default-features = false, features = ["std"] }
 tokio = "0.2.6"
 tokio-util = "0.2.0"
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -13,7 +13,7 @@ use actix_web::{error, Error, HttpMessage};
 use futures::future::{ok, Future, Ready};
 use rand::{distributions::Alphanumeric, rngs::OsRng, Rng};
 use redis_async::resp::RespValue;
-use time::{self, Duration};
+use time::{Duration, OffsetDateTime};
 
 use crate::redis::{Command, RedisActor};
 
@@ -351,7 +351,7 @@ impl Inner {
         let mut cookie = Cookie::named(self.name.clone());
         cookie.set_value("");
         cookie.set_max_age(Duration::seconds(0));
-        cookie.set_expires(time::now() - Duration::days(365));
+        cookie.set_expires(OffsetDateTime::now() - Duration::days(365));
 
         let val = HeaderValue::from_str(&cookie.to_string())
             .map_err(error::ErrorInternalServerError)?;
@@ -372,7 +372,7 @@ mod test {
     };
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use time;
+    use time::OffsetDateTime;
 
     #[derive(Serialize, Deserialize, Debug, PartialEq)]
     pub struct IndexResponse {
@@ -632,7 +632,7 @@ mod test {
             .into_iter()
             .find(|c| c.name() == "test-session")
             .unwrap();
-        assert!(&time::now().tm_year != &cookie_4.expires().map(|t| t.tm_year).unwrap());
+        assert!(&OffsetDateTime::now().year() != &cookie_4.expires().map(|t| t.year()).unwrap());
 
         // Step 10: GET index, including session cookie #2 in request
         //   - set-cookie actix-session will be in response (session cookie #3)


### PR DESCRIPTION
This requires that [this actix-web pull request](https://github.com/actix/actix-web/pull/1254) is merged, and for this crate's `actix-http` (which is pulled in using the `web` feature via `actix`, so `actix` itself needs `actix-http` updated), `actix-web`, and `actix-session` versions be upgraded as well before it'll compile.